### PR TITLE
"item_iterator()" is now a Generator and is more resilient to unknown requests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# PyCharm
+.idea

--- a/README.MD
+++ b/README.MD
@@ -48,16 +48,18 @@ python setup.py install
 ###Iterators:
 
 When working with the <code>limit</code> parameters (default value is **100**) you can request resources using the <code>item_iterator()</code> function.
-Using the <code>hasMore</code> flag it will request items until the value of the flag is **False**.
+The API returns data in pages. This function returns a [Generator](https://wiki.python.org/moin/Generators) which
+traverses these pages for you and yields each result in the current page before retrieving the next page.
 
 ##Example usage:
 
 ```python
 >>> import usabilla as ub
+>>> import json
 >>> clientApi = ub.APIClient('CLIENT-API-KEY', 'CLIENT-SECRET-KEY')
 >>> clientApi.set_query_parameters({'limit' : 1})
->>> feedbackItems = clientApi.item_iterator({'type':'feedbackItems', 'id' : '8d73568ac2be'})
->>> print feedbackItems
+>>> feedbackItems = clientApi.item_iterator('feedback_items', '8d73568ac2be')
+>>> print json.dumps([item for item in feedbackItems], indent=4)
 ```
 
 Where <code>id</code> is the button id from which the feedback originates.

--- a/examples/feedback_iterator_example.py
+++ b/examples/feedback_iterator_example.py
@@ -11,6 +11,6 @@ if __name__ == '__main__':
     client_api.set_query_parameters({'limit': 1})
 
     # Get the feedback items for a specific button
-    feedback_items = client_api.item_iterator({'type': 'feedback_items', 'id': 'BUTTON-ID'})
+    feedback_items = client_api.item_iterator('feedback_items', 'BUTTON-ID')
 
-    pprint.PrettyPrinter(indent=4).pprint(feedback_items)
+    pprint.PrettyPrinter(indent=4).pprint([item for item in feedback_items])

--- a/usabilla.py
+++ b/usabilla.py
@@ -253,7 +253,7 @@ class APIClient(object):
                 for item in results['items']:
                     yield item
                 self.set_query_parameters({'since': results['lastTimestamp']})
-            except GeneralError, requests.HTTPError:
+            except:
                 pass
 
     def _get_iterator_function(self, resource_group):


### PR DESCRIPTION
When calling "item_iterator()" previously, all data about the resource was loaded into memory and then returned. Now it loads each page one at a time and yields each element in the page before retrieving another - lower memory footprint.

If the user requests a resource_group that we do not know about then a GeneralException is raised instead of a key error (get_iterator_dispatcher returned a dict which we manually tried to access, now it's encapsulated in _get_iterator_function which returns None if no iterator can be found.)
