### PR TITLE
Reuse connections when making API calls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,11 @@ Changelog
 
 Here you find a full list of changes.
 
+Version 2.0.1
+-------------
+
+- Reuse HTTP connections between requests
+
 Version 2.0.0
 -------------
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-VERSION = '2.0.0'
+VERSION = '2.0.1'
 
 setup(
     name='usabilla-api',

--- a/usabilla.py
+++ b/usabilla.py
@@ -127,6 +127,8 @@ class APIClient(object):
     host = 'data.usabilla.com'
     host_protocol = 'https://'
 
+    session = requests.Session()
+
     def __init__(self, client_key, secret_key):
         """Initialize an APIClient object."""
         self.query_parameters = ''
@@ -237,7 +239,7 @@ class APIClient(object):
 
         # Send the request.
         request_url = self.host + scope + '?' + canonical_querystring
-        r = requests.get(self.host_protocol + request_url, headers=headers)
+        r = self.session.get(self.host_protocol + request_url, headers=headers)
         r.raise_for_status()
 
         return r.json()


### PR DESCRIPTION
By default, the Python requests module will create a new session object each time it is called. This means that each requests.get call has a separate connection pool and cannot reuse connections created by previous requests.

Here we create a class variable with a requests session, which is used for all instances of the APIClient class.

This does mean that sessions will now be shared between all APIClient objects in a process, even if they use different credentials. I do not believe this is a problem because requests are independently authenticated, but I would appreciate a review from someone more familiar with this code anyway.