### PR TITLE
APIClient::item_iterator: reset query_parameters after returning all items

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Version 2.0.2
+-------------
+
+- Reset query arguments after returning all items from generator
+
 Here you find a full list of changes.
 
 Version 2.0.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-VERSION = '2.0.1'
+VERSION = '2.0.2'
 
 setup(
     name='usabilla-api',

--- a/usabilla.py
+++ b/usabilla.py
@@ -311,6 +311,8 @@ class APIClient(object):
                 yield item
             self.set_query_parameters({'since': results['lastTimestamp']})
 
+        self.set_query_parameters({})
+
     def get_resource(self, scope, product, resource, resource_id=None, iterate=False):
         """Retrieves resources of the specified type
 


### PR DESCRIPTION
The item_iterator method uses a query parameter called `since` to get the next results from the API resource when the previous response includes a hasMore=True property.

The problem here is the last API call leaves the query parameter defined to a value related to the previous resource retrieved, and if you use the same api client to iterate over different resources (i.e. campaigns), the results will always be affected by the previous call.

In the case below, since the `api` variable is defined outside the loop (as expected), responses for campaign `22222` will be affected by the `since` property from the last call to campaign `11111` resulting in fewer responses or, in many cases, empty result.

**Example:**
```python
campaign_id_list = ['11111', '22222']
all_responses = []
api = ub.APIClient('my-client-key', 'my-secret-key')

for campaign_id in campaign_id_list:
    campaign_responses = api.get_resource(api.SCOPE_LIVE, api.PRODUCT_WEBSITES, api.RESOURCE_CAMPAIGN_RESULT, campaign_id, iterate=True)

    campaign_responses = [item['id'] for item in campaign_responses]
    all_responses += campaign_responses

print(len(all_responses))
```

It's probably the same issue reported [here](https://github.com/usabilla/api-python/issues/20).


