### PR TITLE
Add support for new Schema Endpoint

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -113,6 +113,12 @@ class TestClient(TestCase):
                 'apps',
                 'campaign_result'),
             '/live/apps/campaign/:id/results')
+        self.assertEqual(
+            self.client.check_resource_validity(
+                'live',
+                'apps',
+                'campaign_result_schema'),
+            '/live/apps/campaign/:id/results/schema')
 
     def test_handle_id(self):
         url = '/live/websites/button/:id/feedback'
@@ -166,6 +172,8 @@ class TestClient(TestCase):
         self.client.send_signed_request.assert_called_with('/live/websites/button/42/feedback')
         self.client.get_resource('live', 'websites', 'button', None, True)
         self.client.item_iterator.assert_called_with('/live/websites/button')
+        self.client.get_resource('live', 'apps', 'campaign_result_schema', 42)
+        self.client.send_signed_request.assert_called_with('/live/apps/campaign/42/results/schema')
 
 
 if __name__ == '__main__':

--- a/usabilla.py
+++ b/usabilla.py
@@ -97,7 +97,8 @@ class APIClient(object):
                             'app': '',
                             'feedback': '/:id/feedback',
                             'campaign': '/campaign',
-                            'campaign_result': '/campaign/:id/results'
+                            'campaign_result': '/campaign/:id/results',
+                            'campaign_result_schema': '/campaign/:id/results/schema'
                         }
                     }
                 }
@@ -120,6 +121,7 @@ class APIClient(object):
     RESOURCE_CAMPAIGN = 'campaign'
     RESOURCE_CAMPAIGN_RESULT = 'campaign_result'
     RESOURCE_CAMPAIGN_STATS = 'campaign_stats'
+    RESOURCE_CAMPAIGN_RESULT_SCHEMA = 'campaign_result_schema'
     RESOURCE_INPAGE = 'inpage'
     RESOURCE_INPAGE_RESULT = 'inpage_result'
 


### PR DESCRIPTION
This adds support for the new endpoint that offers the schema of campaign results for a given campaign.
That endpoint comes from [GFPACT-1428](https://momentiveai.atlassian.net/browse/GFPACT-1428)

[GFPACT-1428]: https://momentiveai.atlassian.net/browse/GFPACT-1428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ