### PR TITLE
Remove dependency on urllib3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run Tests
+        run: |
+          python tests.py

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@ Changelog
 =========
 Here you find a full list of changes.
 
+
+Version 2.0.4
+-------------
+
+- Remove usage of urllib3 which was restricted to v1 in favor of embedded urllib to simplify our dependencies
+- Update dependencies
+
 Version 2.0.3
 -------------
 

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,8 @@ For more information on resources, authorization and available API calls, please
 
 ## Installation:
 
-Requires Python 2.7
+Requires Python 3. 
+Support for Python 2.7 is expected but not tested or validated.
 
 ```bash
 pip install usabilla-api

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-coverage==4.0.3
-python-coveralls==2.7.0
-PyYAML==4.2b1
-requests==2.20.0
-sh==1.11
-six==1.10.0
-mock==2.0.0
+coverage==7.3.0
+python-coveralls==2.9.3
+PyYAML==6.0.1
+requests==2.31.0
+sh==2.0.6
+six==1.16.0
+mock==5.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,4 @@ PyYAML==4.2b1
 requests==2.20.0
 sh==1.11
 six==1.10.0
-urllib3==1.23
 mock==2.0.0

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ try:
 except ImportError:
     from distutils.core import setup
 
-VERSION = '2.0.3'
+VERSION = '2.0.4'
 
 setup(
     name='usabilla-api',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     version=VERSION,
     description="Python client for Usabilla API",
     license='MIT',
-    install_requires=['urllib3', 'requests'],
+    install_requires=['requests'],
     packages=find_packages(),
     py_modules=['usabilla'],
     author='Usabilla',

--- a/tests.py
+++ b/tests.py
@@ -84,6 +84,9 @@ class TestClient(TestCase):
         params = {'limit': 1, 'since': 1235454}
         self.client.set_query_parameters(params)
         self.assertEqual(self.client.get_query_parameters(), 'limit=1&since=1235454')
+        params = {'limit': 1, 'since': 1235454, 'text': 'the little old lady'}
+        self.client.set_query_parameters(params)
+        self.assertEqual(self.client.get_query_parameters(), 'limit=1&since=1235454&text=the+little+old+lady')
 
     def test_check_resource_validity(self):
         with self.assertRaises(ub.GeneralError):

--- a/usabilla.py
+++ b/usabilla.py
@@ -22,7 +22,7 @@ import datetime
 import hashlib
 import hmac
 import requests
-import urllib3.request as urllib
+import urllib.parse
 
 from collections import OrderedDict
 
@@ -153,7 +153,7 @@ class APIClient(object):
         :type parameters: dict
         """
 
-        self.query_parameters = urllib.urlencode(OrderedDict(sorted(parameters.items())))
+        self.query_parameters = urllib.parse.urlencode(OrderedDict(sorted(parameters.items())))
 
     def get_query_parameters(self):
         """Get the query parameters."""


### PR DESCRIPTION
Our usage is incompatible with `urllib3:v2` and can be catered by `urllib`. 
Closes #28 