### PR TITLE
Add Tests Setup

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: Run Tests
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+      - name: Run Tests
+        run: |
+          python tests.py

--- a/README.MD
+++ b/README.MD
@@ -33,7 +33,8 @@ For more information on resources, authorization and available API calls, please
 
 ## Installation:
 
-Requires Python 2.7
+Requires Python 3. 
+Support for Python 2.7 is expected but not tested or validated.
 
 ```bash
 pip install usabilla-api


### PR DESCRIPTION
Transitioning to maintenance mode means we have less people working on this, adding automated tests will help avoid problems.